### PR TITLE
Implement the moderate_user flag in apply_binds

### DIFF
--- a/src/commands/unbind.py
+++ b/src/commands/unbind.py
@@ -3,11 +3,11 @@ import json
 import hikari
 
 from resources.autocomplete import bind_category_autocomplete, bind_id_autocomplete
-from resources.binds import GroupBind, GuildBind, delete_bind, json_binds_to_guild_binds
+from resources.binds import delete_bind, json_binds_to_guild_binds
 from resources.bloxlink import instance as bloxlink
 from resources.component_helper import component_author_validation, get_custom_id_data
 from resources.exceptions import RobloxAPIError
-from resources.models import CommandContext
+from resources.models import CommandContext, GroupBind, GuildBind
 from resources.pagination import Paginator
 
 MAX_BINDS_PER_PAGE = 15

--- a/src/commands/update.py
+++ b/src/commands/update.py
@@ -31,4 +31,4 @@ class UpdateCommand:
             ctx.member, ctx.guild_id, roblox_account, moderate_user=True
         )
 
-        await ctx.response.send(embed=message_response)
+        await ctx.response.send(embed=message_response.embed, components=message_response.components)

--- a/src/commands/verify.py
+++ b/src/commands/verify.py
@@ -6,7 +6,7 @@ from resources.models import CommandContext
 
 @bloxlink.command(category="Account", defer=True)
 class VerifyCommand:
-    """link your Roblox account to your Discord account and get your server roles"""
+    """Link your Roblox account to your Discord account and get your server roles."""
 
     async def __main__(self, ctx: CommandContext):
         roblox_account = await users.get_user_account(ctx.user, raise_errors=False)
@@ -14,8 +14,8 @@ class VerifyCommand:
             ctx.member, ctx.guild_id, roblox_account, moderate_user=True
         )
 
-        if not roblox_account:
-            await ctx.response.send("not verified")
-            return
+        # if not roblox_account:
+        #     await ctx.response.send("not verified")
+        #     return
 
-        await ctx.response.send(embed=message_response)
+        await ctx.response.send(embed=message_response.embed, components=message_response.components)

--- a/src/commands/viewbinds.py
+++ b/src/commands/viewbinds.py
@@ -1,17 +1,12 @@
 import hikari
 
 from resources.autocomplete import bind_category_autocomplete, bind_id_autocomplete
-from resources.binds import (
-    GroupBind,
-    GuildBind,
-    join_bind_strings,
-    json_binds_to_guild_binds,
-)
+from resources.binds import join_bind_strings, json_binds_to_guild_binds
 from resources.bloxlink import instance as bloxlink
 from resources.component_helper import component_author_validation, get_custom_id_data
 from resources.constants import RED_COLOR, UNICODE_BLANK
 from resources.exceptions import RobloxAPIError, RobloxNotFound
-from resources.models import CommandContext
+from resources.models import CommandContext, GroupBind, GuildBind
 from resources.pagination import Paginator
 
 MAX_BINDS_PER_PAGE = 5

--- a/src/resources/autocomplete.py
+++ b/src/resources/autocomplete.py
@@ -1,7 +1,7 @@
 import hikari
 
-from resources.binds import GuildBind
 from resources.bloxlink import instance as bloxlink
+from resources.models import GuildBind
 
 
 async def bind_category_autocomplete(interaction: hikari.AutocompleteInteraction):

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -178,6 +178,26 @@ async def apply_binds(
     *,
     moderate_user=False,
 ) -> hikari.Embed:
+    """Apply bindings to a user, (apply the Verified & Unverified roles, nickname template, and custom bindings).
+
+    Args:
+        member (hikari.Member | dict): Information of the member being updated.
+            For dicts, the valid keys are as follows:
+            "role_ids", "id", "username" (or "name"), "nickname", "avatar_url"
+        guild_id (hikari.Snowflake): The ID of the guild where the user is being updated.
+        roblox_account (users.RobloxAccount, optional): The linked account of the user if one exists. May
+            or may not be their primary account, could be a guild-specific link. Defaults to None.
+        moderate_user (bool, optional): Check if any restrictions (age limit, group lock,
+            ban evasion, alt detection) apply to this user. Defaults to False.
+
+    Raises:
+        Message: Raised if there was an issue getting a server's bindings.
+        RuntimeError: Raised if the nickname endpoint on the bot API encountered an issue.
+        BloxlinkForbidden: Raised when Bloxlink does not have permissions to give roles to a user.
+
+    Returns:
+        hikari.Embed: The embed that will be shown to the user.
+    """
     if roblox_account and roblox_account.groups is None:
         await roblox_account.sync(["groups"])
 
@@ -190,7 +210,7 @@ async def apply_binds(
     avatar_url = ""
     user_tag = ""
 
-    # Get necessary use information.
+    # Get necessary user information.
     if isinstance(member, hikari.Member):
         role_ids = member.role_ids
         member_id = member.id

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -272,6 +272,8 @@ async def apply_binds(
                 "been kicked from this server."
             )
 
+    restricted_flag = False if (restrict_result is None or restrict_result.restriction == "disallowAlts") else True
+
     # TODO: Add restricted flag so that way only the unverified role is given if a user is restricted.
     # Get user's bindings (includes verified + unverified roles) to apply + nickname templates.
     user_binds, user_binds_response = await fetch(
@@ -288,6 +290,7 @@ async def apply_binds(
             },
             "member": {"id": member_id, "roles": member_roles},
             "roblox_account": roblox_account.to_dict() if roblox_account else None,
+            "restricted": restricted_flag
         },
     )
 
@@ -341,6 +344,7 @@ async def apply_binds(
                     "guild_name": guild.name,
                     "roblox_account": roblox_account.to_dict() if roblox_account else None,
                     "template": chosen_nickname,
+                    "restricted": restricted_flag,
                 },
             )
 

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -1,34 +1,24 @@
 from __future__ import annotations
 
-import logging
 import re
-from dataclasses import dataclass
 from typing import Literal
 
 import hikari
 
+import resources.restriction as restriction
 import resources.roblox.users as users
-from resources.constants import (
-    GROUP_RANK_CRITERIA_TEXT,
-    RED_COLOR,
-    REPLY_CONT,
-    REPLY_EMOTE,
-)
+from resources.bloxlink import instance as bloxlink
+from resources.constants import GROUP_RANK_CRITERIA_TEXT, REPLY_CONT, REPLY_EMOTE
 from resources.exceptions import (
     BloxlinkException,
     BloxlinkForbidden,
     Message,
     RobloxAPIError,
     RobloxNotFound,
-    UserNotVerified,
 )
-from resources.roblox.groups import RobloxGroup
-from resources.roblox.roblox_entity import RobloxEntity, create_entity
-from resources.secrets import BOT_API, BOT_API_AUTH
-
-from .bloxlink import instance as bloxlink
-from .models import GuildData, UserData, default_field
-from .utils import fetch
+from resources.models import GroupBind, GuildBind, GuildData
+from resources.secrets import BOT_API, BOT_API_AUTH  # pylint: disable=E0611
+from resources.utils import fetch
 
 nickname_template_regex = re.compile(r"\{(.*?)\}")
 any_group_nickname = re.compile(r"\{group-rank-(.*?)\}")
@@ -251,7 +241,7 @@ async def apply_binds(
     # Handle restrictions.
     restrict_result = None
     if moderate_user:
-        restrict_result = await _check_guild_restrictions(
+        restrict_result = await restriction.check_guild_restrictions(
             guild_id,
             {
                 "id": member_id,
@@ -276,7 +266,6 @@ async def apply_binds(
         False if (restrict_result is None or restrict_result.restriction == "disallowAlts") else True
     )
 
-    # TODO: Add restricted flag so that way only the unverified role is given if a user is restricted.
     # Get user's bindings (includes verified + unverified roles) to apply + nickname templates.
     user_binds, user_binds_response = await fetch(
         "POST",
@@ -412,390 +401,6 @@ async def apply_binds(
         embed = hikari.Embed(description="No binds apply to you!")
 
     return embed
-
-
-@dataclass
-class Restriction:
-    removed: bool = False
-    action: str | None = Literal["kick", "ban", "dm", None]
-    restriction: str | None = Literal["ageLimit", "groupLock", "disallowAlts", "banEvader", None]
-    metadata: dict = default_field({"unverified": True})
-
-    def prompt(self, guild_name: str) -> hikari.Embed:
-        """Return an Embed describing why the user was restricted.
-
-        This prompt will be either DM'd to users or sent in replacement of the typical
-        verification success message.
-        The only time it is not sent for a restriction is for the disallowAlts restriction, where instead
-        a reason will be appended to the success embed as a warning.
-
-        Args:
-            guild_name (str): Name of the guild that the user was trying to verify in.
-
-        Returns:
-            hikari.Embed: User-facing embed.
-        """
-        embed = hikari.Embed()
-
-        embed.set_author(name=f"You could not be verified in {guild_name.capitalize()}!")
-
-        unverified: bool = self.metadata["unverified"]
-        description = "You are not verified with Bloxlink!"
-
-        try:
-            if unverified:
-                raise UserNotVerified()
-
-            match self.restriction:
-                case "ageLimit":
-                    age_limit_data = self.metadata["ageLimit"]
-                    description = (
-                        "Your linked Roblox account is not old enough to verify in this server!\n"
-                        f"Your account needs to be {age_limit_data[0]} days old, "
-                        f"and is only {age_limit_data[1]} days old."
-                    )
-
-                case "groupLock":
-                    group: RobloxGroup = self.metadata["group"]
-                    roleset_restriction = self.metadata["roleset"]
-                    dm_message = self.metadata["dmMessage"]
-
-                    if roleset_restriction:
-                        description = (
-                            "You are not the required rank in "
-                            f"[{group.name}](https://www.roblox.com/groups/{group.id})!"
-                        )
-                    else:
-                        description = (
-                            "This server requires that you join "
-                            f"[{group.name}](https://www.roblox.com/groups/{group.id}) "
-                            "before you can verify!"
-                        )
-
-                    if dm_message:
-                        description += f"\nMessage from the server admins:\n>>> *{dm_message}*"
-
-                case "disallowAlts":
-                    # unused?
-                    description = (
-                        "This server allows you be verified to one Discord account at a time."
-                        "Because of this your other accounts linked to your Roblox account have been kicked"
-                        "from this server."
-                    )
-
-                case "banEvader":
-                    description = "You have been removed because you are evading a ban in this server."
-
-        except UserNotVerified:
-            pass
-
-        embed.color = RED_COLOR
-        embed.description = description
-
-        return embed
-
-    async def moderate(self, user_id: int, guild: hikari.Guild):
-        """DM, Kick, or Ban a user based on the determined restriction.
-
-        Args:
-            user_id (int): ID of the user to moderate.
-            guild (hikari.Guild): The guild that the user is verifying in.
-        """
-        if self.removed or self.action is None or self.restriction is None:
-            return
-
-        prompt = self.prompt(guild.name)
-        try:
-            # Only DM if the user is being kicked or banned.
-            if self.action != "dm":
-                channel = await bloxlink.rest.create_dm_channel(user_id)
-                await channel.send(embed=prompt)
-
-        except (hikari.BadRequestError, hikari.ForbiddenError, hikari.NotFoundError) as e:
-            logging.warning(e)
-
-        try:
-            log_reason = self._log_reason()
-            if self.action == "kick":
-                await bloxlink.rest.kick_user(guild.id, user_id, reason=log_reason)
-            elif self.action == "ban":
-                await bloxlink.rest.ban_user(guild.id, user_id, reason=log_reason)
-
-        except (hikari.ForbiddenError, hikari.NotFoundError):
-            pass
-        else:
-            if self.action != "dm":
-                self.removed = True
-
-    def _log_reason(self) -> str:
-        """Generate a string for the audit log entry when a user is kicked or banned.
-
-        Returns:
-            str: The resulting audit log string.
-        """
-        response: str = f"RESTRICTED: {self.restriction}, "
-
-        unverified: bool = self.metadata["unverified"]
-        description = "Not verified with Bloxlink."
-
-        try:
-            if unverified:
-                raise UserNotVerified()
-
-            match self.restriction:
-                case "ageLimit":
-                    age_limit_data = self.metadata["ageLimit"]
-                    description = (
-                        "User's Roblox account does not meet the agelimit. "
-                        f"{age_limit_data[1]} < {age_limit_data[0]} days."
-                    )
-
-                case "groupLock":
-                    group: RobloxGroup = self.metadata["group"]
-                    roleset_restriction = self.metadata["roleset"]
-
-                    if roleset_restriction:
-                        description = f"User is not the required rank in the group {str(group)}"
-                    else:
-                        description = f"User is not in the group {str(group)}"
-
-                case "banEvader":
-                    banned_id = self.metadata["banned_user"]
-                    description = f"User is an alt of the banned account {banned_id}"
-
-                case _:
-                    description = "User matched a restriction."
-        except UserNotVerified:
-            pass
-
-        return response + description
-
-
-async def _check_guild_restrictions(guild_id: hikari.Snowflake, user_info: dict) -> Restriction | None:
-    """Check if a user should be kept from verifying in this guild_id.
-
-    Args:
-        guild_id (hikari.Snowflake): ID of the guild that the user is verifying in.
-        user_info (dict): Information of the user
-            Expected to have "id": the user id, and "account" which is a RobloxAccount.
-
-    Returns:
-        Restriction | None: Restriction info if the user should be restricted.
-    """
-    guild_data = await bloxlink.fetch_guild_data(
-        guild_id,
-        "ageLimit",
-        "disallowAlts",
-        "disallowBanEvaders",
-        "groupLock",
-    )
-
-    user_id = user_info["id"]
-    user_acc: users.RobloxAccount = user_info["account"]
-
-    # TODO: If server has premium and user_acc
-    if user_acc:
-        bloxlink_user: UserData = await bloxlink.fetch_user_data(user_id, "robloxID", "robloxAccounts")
-
-        accounts = bloxlink_user.robloxAccounts["accounts"]
-        accounts.append(bloxlink_user.robloxID)
-        accounts = list(set(accounts))
-
-        result = await _check_premium_restrictions(
-            guild_data.disallowAlts,
-            guild_data.disallowBanEvaders,
-            user_id,
-            guild_id,
-            accounts,
-        )
-
-        if result:
-            return result
-
-    if guild_data.ageLimit:
-        if not user_acc:
-            return Restriction(action="kick", restriction="ageLimit", metadata={"unverified": True})
-
-        if user_acc.age_days < guild_data.ageLimit:
-            return Restriction(
-                action="kick",
-                restriction="ageLimit",
-                metadata={"unverified": False, "ageLimit": (guild_data.ageLimit, user_acc.age_days)},
-            )
-
-    if guild_data.groupLock:
-        if not user_acc:
-            kick_unverified = any(
-                g.get("unverifiedAction", "kick") == "kick" for g in guild_data.groupLock.values()
-            )
-
-            return Restriction(
-                action="kick" if kick_unverified else "dm",
-                restriction="groupLock",
-                metadata={"unverified": True},
-            )
-
-        if user_acc.groups is None:
-            await user_acc.sync(includes=["groups"])
-
-        for group_id, group_data in guild_data.groupLock.items():
-            action = group_data.get("verifiedAction", "dm")
-            required_rolesets = group_data.get("roleSets")
-
-            dm_message = group_data.get("dmMessage")
-
-            group_match: RobloxGroup = user_acc.groups.get(group_id)
-            group = group_match if group_match is not None else RobloxGroup(group_id)
-            await group.sync()
-
-            if group_match is None:
-                return Restriction(
-                    action=action,
-                    restriction="groupLock",
-                    metadata={"unverified": False, "group": group, "dmMessage": dm_message, "roleset": False},
-                )
-
-            user_roleset = group_match.user_roleset["rank"]
-            for roleset in required_rolesets:
-                if isinstance(roleset, list):
-                    # within range
-                    if roleset[0] <= user_roleset <= roleset[1]:
-                        break
-                else:
-                    # exact match (x) or inverse match (rolesets above x)
-                    if (user_roleset == roleset) or (roleset < 0 and abs(roleset) <= user_roleset):
-                        break
-            else:
-                # no match was found - restrict the user.
-                return Restriction(
-                    action=action,
-                    restriction="groupLock",
-                    metadata={"unverified": False, "group": group, "dmMessage": dm_message, "roleset": True},
-                )
-
-
-async def _check_premium_restrictions(
-    check_alts: bool,
-    check_ban_evaders: str | None,
-    user_id: int,
-    guild_id: int,
-    user_accounts: list,
-) -> Restriction | None:
-    """Check for alts and ban evaders within a server for a user.
-
-    Args:
-        check_alts (bool): Should we check for alts
-        check_ban_evaders (str | None): Should we check for ban evaders
-        user_id (int): Discord ID of the user being updated
-        guild_id (int): Guild ID where the user is being updated
-        user_accounts (list): Roblox accounts linked to this user_id
-
-    Returns:
-        Restriction | None: Restriction info if the user is ban evading or an alt account
-            was found.
-    """
-    if not check_alts and (not check_ban_evaders or check_ban_evaders is None):
-        return
-
-    matches = []
-    for account in user_accounts:
-        matches.extend(await bloxlink.reverse_lookup(account, user_id))
-
-    alts_found: bool = False
-    for user in matches:
-        # sanity check, shouldn't be included but just in case.
-        if str(user_id) == user:
-            continue
-
-        if check_alts:
-            member = await bloxlink.fetch_discord_member(guild_id, user, "id")
-
-            if member is not None:
-                # We kick the old user here because otherwise the restriction will remove the original
-                # user based on the code setup.
-
-                try:
-                    await bloxlink.rest.kick_user(
-                        guild_id, user, reason=f"User is an alt of {user_id} and disallowAlts is enabled."
-                    )
-
-                    alts_found = True
-
-                except (hikari.NotFoundError, hikari.ForbiddenError):
-                    pass
-
-                # We don't return so we can continue checking for more alts if they exist & kick them too.
-                # Plus, returning will prevent ban evader checking.
-
-        if check_ban_evaders:
-            try:
-                await bloxlink.rest.fetch_ban(guild_id, user)
-            except hikari.NotFoundError:
-                continue
-            except hikari.ForbiddenError:
-                continue
-            else:
-                return Restriction(
-                    action="ban",
-                    restriction="banEvader",
-                    metadata={"unverified": False, "banned_user": user},
-                )
-
-        if alts_found:
-            return Restriction(
-                action="dm",
-                restriction="disallowAlts",
-                metadata={"unverified": False},
-            )
-
-
-@dataclass(slots=True)
-class GuildBind:
-    nickname: str = None
-    roles: list = default_field(list())
-    removeRoles: list = default_field(list())
-
-    id: int = None
-    type: Literal["group", "asset", "gamepass", "badge"] = Literal["group", "asset", "gamepass", "badge"]
-    bind: dict = default_field({"type": "", "id": None})
-
-    entity: RobloxEntity = None
-
-    def __post_init__(self):
-        self.id = self.bind.get("id")
-        self.type = self.bind.get("type")
-
-        self.entity = create_entity(self.type, self.id)
-
-
-class GroupBind(GuildBind):
-    min: int = None
-    max: int = None
-    roleset: int = None
-    everyone: bool = None
-    guest: bool = None
-
-    def __post_init__(self):
-        self.min = self.bind.get("min", None)
-        self.max = self.bind.get("max", None)
-        self.roleset = self.bind.get("roleset", None)
-        self.everyone = self.bind.get("everyone", None)
-        self.guest = self.bind.get("guest", None)
-
-        return super().__post_init__()
-
-    @property
-    def subtype(self) -> str:
-        """Returns the type of group bind that this is.
-
-        Returns:
-            str: Either "linked_group" or "group_roles" depending on if there
-                are roles explicitly listed to be given or not.
-        """
-        if not self.roles or self.roles in ("undefined", "null"):
-            return "linked_group"
-        else:
-            return "group_roles"
 
 
 def json_binds_to_guild_binds(bind_list: list, category: str = None, id_filter: str = None):

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -16,7 +16,7 @@ from resources.exceptions import (
     RobloxAPIError,
     RobloxNotFound,
 )
-from resources.models import GroupBind, GuildBind, GuildData
+from resources.models import EmbedPrompt, GroupBind, GuildBind, GuildData
 from resources.secrets import BOT_API, BOT_API_AUTH  # pylint: disable=E0611
 from resources.utils import fetch
 
@@ -167,7 +167,7 @@ async def apply_binds(
     roblox_account: users.RobloxAccount = None,
     *,
     moderate_user=False,
-) -> hikari.Embed:
+) -> EmbedPrompt:
     """Apply bindings to a user, (apply the Verified & Unverified roles, nickname template, and custom bindings).
 
     Args:
@@ -186,7 +186,8 @@ async def apply_binds(
         BloxlinkForbidden: Raised when Bloxlink does not have permissions to give roles to a user.
 
     Returns:
-        hikari.Embed: The embed that will be shown to the user.
+        EmbedPrompt: The embed that will be shown to the user, may or may not include the components that
+            will be shown, depending on if the user is restricted or not.
     """
     if roblox_account and roblox_account.groups is None:
         await roblox_account.sync(["groups"])
@@ -400,7 +401,7 @@ async def apply_binds(
     else:
         embed = hikari.Embed(description="No binds apply to you!")
 
-    return embed
+    return EmbedPrompt(embed, components=[])
 
 
 def json_binds_to_guild_binds(bind_list: list, category: str = None, id_filter: str = None):

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -272,7 +272,9 @@ async def apply_binds(
                 "been kicked from this server."
             )
 
-    restricted_flag = False if (restrict_result is None or restrict_result.restriction == "disallowAlts") else True
+    restricted_flag = (
+        False if (restrict_result is None or restrict_result.restriction == "disallowAlts") else True
+    )
 
     # TODO: Add restricted flag so that way only the unverified role is given if a user is restricted.
     # Get user's bindings (includes verified + unverified roles) to apply + nickname templates.
@@ -290,7 +292,7 @@ async def apply_binds(
             },
             "member": {"id": member_id, "roles": member_roles},
             "roblox_account": roblox_account.to_dict() if roblox_account else None,
-            "restricted": restricted_flag
+            "restricted": restricted_flag,
         },
     )
 

--- a/src/resources/bloxlink.py
+++ b/src/resources/bloxlink.py
@@ -204,6 +204,24 @@ class Bloxlink(yuyo.AsgiBot):
             ]
         )
 
+    async def reverse_lookup(self, roblox_id: int, origin_id: int | None = None) -> list[str]:
+        """Find Discord IDs linked to a roblox id.
+
+        Args:
+            roblox_id (int): The roblox user ID that will be matched against.
+            origin_id (int | None, optional): Discord user ID that will not be included in the output.
+                Defaults to None.
+
+        Returns:
+            list[str]: All the discord IDs linked to this roblox_id.
+        """
+        cursor = self.mongo.bloxlink["users"].find(
+            {"$or": [{"robloxID": roblox_id}, {"robloxAccounts.accounts": roblox_id}]},
+            {"_id": 1},
+        )
+
+        return [x["_id"] async for x in cursor if str(origin_id) != str(x["_id"])]
+
     @staticmethod
     def load_module(import_name: str) -> None:
         try:

--- a/src/resources/models.py
+++ b/src/resources/models.py
@@ -1,20 +1,23 @@
 import copy
-from abc import ABC
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import hikari
+
+from resources.roblox.roblox_entity import RobloxEntity, create_entity
 
 from .response import Response
 
 __all__ = (
-    "UserData",
-    "GuildData",
-    "RobloxAccount",
     "CommandContext",
-    "PremiumModel",
+    "EmbedPrompt",
+    "GroupBind",
+    "GuildBind",
+    "GuildData",
     "MISSING",
+    "PremiumModel",
+    "UserData",
 )
 
 
@@ -102,3 +105,58 @@ class PremiumModel:
 
 class MISSING:
     pass
+
+
+@dataclass(slots=True)
+class EmbedPrompt:
+    embed: hikari.Embed = hikari.Embed()
+    components: list = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class GuildBind:
+    nickname: str = None
+    roles: list = default_field(list())
+    removeRoles: list = default_field(list())
+
+    id: int = None
+    type: Literal["group", "asset", "gamepass", "badge"] = Literal["group", "asset", "gamepass", "badge"]
+    bind: dict = default_field({"type": "", "id": None})
+
+    entity: RobloxEntity = None
+
+    def __post_init__(self):
+        self.id = self.bind.get("id")
+        self.type = self.bind.get("type")
+
+        self.entity = create_entity(self.type, self.id)
+
+
+class GroupBind(GuildBind):
+    min: int = None
+    max: int = None
+    roleset: int = None
+    everyone: bool = None
+    guest: bool = None
+
+    def __post_init__(self):
+        self.min = self.bind.get("min", None)
+        self.max = self.bind.get("max", None)
+        self.roleset = self.bind.get("roleset", None)
+        self.everyone = self.bind.get("everyone", None)
+        self.guest = self.bind.get("guest", None)
+
+        return super().__post_init__()
+
+    @property
+    def subtype(self) -> str:
+        """Returns the type of group bind that this is.
+
+        Returns:
+            str: Either "linked_group" or "group_roles" depending on if there
+                are roles explicitly listed to be given or not.
+        """
+        if not self.roles or self.roles in ("undefined", "null"):
+            return "linked_group"
+        else:
+            return "group_roles"

--- a/src/resources/models.py
+++ b/src/resources/models.py
@@ -54,6 +54,11 @@ class GuildData:
     unverifiedRoleName: str = "Unverified"  # deprecated
     unverifiedRole: str = None
 
+    ageLimit: int = None
+    disallowAlts: bool = None
+    disallowBanEvaders: str = None  # Site sets it to "ban" when enabled. Null when disabled.
+    groupLock: dict = None
+
     premium: dict = None
 
 

--- a/src/resources/prompts.py
+++ b/src/resources/prompts.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass, field
 from typing import Literal
 
 import hikari
@@ -7,14 +6,9 @@ from resources.binds import count_binds, get_bind_desc
 from resources.bloxlink import instance as bloxlink
 from resources.constants import GROUP_RANK_CRITERIA
 from resources.exceptions import RobloxNotFound
+from resources.models import EmbedPrompt
 from resources.roblox.groups import get_group
 from resources.roblox.roblox_entity import create_entity
-
-
-@dataclass(slots=True)
-class EmbedPrompt:
-    embed: hikari.Embed = hikari.Embed()
-    components: list = field(default_factory=list)
 
 
 async def build_interactive_bind_base(

--- a/src/resources/restriction.py
+++ b/src/resources/restriction.py
@@ -14,6 +14,8 @@ from resources.roblox.groups import RobloxGroup
 
 @dataclass
 class Restriction:
+    """Representation of how a restriction applies to a user, if at all."""
+
     removed: bool = False
     action: str | None = Literal["kick", "ban", "dm", None]
     restriction: str | None = Literal["ageLimit", "groupLock", "disallowAlts", "banEvader", None]

--- a/src/resources/restriction.py
+++ b/src/resources/restriction.py
@@ -1,0 +1,347 @@
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+import hikari
+
+import resources.roblox.users as users
+from resources.bloxlink import instance as bloxlink
+from resources.constants import RED_COLOR
+from resources.exceptions import UserNotVerified
+from resources.models import EmbedPrompt, UserData, default_field
+from resources.roblox.groups import RobloxGroup
+
+
+@dataclass
+class Restriction:
+    removed: bool = False
+    action: str | None = Literal["kick", "ban", "dm", None]
+    restriction: str | None = Literal["ageLimit", "groupLock", "disallowAlts", "banEvader", None]
+    metadata: dict = default_field({"unverified": True})
+
+    def prompt(self, guild_name: str) -> EmbedPrompt:
+        """Return an Embed describing why the user was restricted.
+
+        This prompt will be either DM'd to users or sent in replacement of the typical
+        verification success message.
+        The only time it is not sent for a restriction is for the disallowAlts restriction, where instead
+        a reason will be appended to the success embed as a warning.
+
+        Args:
+            guild_name (str): Name of the guild that the user was trying to verify in.
+
+        Returns:
+            EmbedPrompt: User-facing embed.
+        """
+        embed = hikari.Embed()
+
+        embed.set_author(name=f"You could not be verified in {guild_name.capitalize()}!")
+
+        unverified: bool = self.metadata["unverified"]
+        description = "You are not verified with Bloxlink!"
+
+        try:
+            if unverified:
+                raise UserNotVerified()
+
+            match self.restriction:
+                case "ageLimit":
+                    age_limit_data = self.metadata["ageLimit"]
+                    description = (
+                        "Your linked Roblox account is not old enough to verify in this server!\n"
+                        f"Your account needs to be {age_limit_data[0]} days old, "
+                        f"and is only {age_limit_data[1]} days old."
+                    )
+
+                case "groupLock":
+                    group: RobloxGroup = self.metadata["group"]
+                    roleset_restriction = self.metadata["roleset"]
+                    dm_message = self.metadata["dmMessage"]
+
+                    if roleset_restriction:
+                        description = (
+                            "You are not the required rank in "
+                            f"[{group.name}](https://www.roblox.com/groups/{group.id})!"
+                        )
+                    else:
+                        description = (
+                            "This server requires that you join "
+                            f"[{group.name}](https://www.roblox.com/groups/{group.id}) "
+                            "before you can verify!"
+                        )
+
+                    if dm_message:
+                        description += f"\nMessage from the server admins:\n>>> *{dm_message}*"
+
+                case "disallowAlts":
+                    # unused?
+                    description = (
+                        "This server allows you be verified to one Discord account at a time."
+                        "Because of this your other accounts linked to your Roblox account have been kicked"
+                        "from this server."
+                    )
+
+                case "banEvader":
+                    description = "You have been removed because you are evading a ban in this server."
+
+        except UserNotVerified:
+            pass
+
+        embed.color = RED_COLOR
+        embed.description = description
+
+        return EmbedPrompt(embed=embed, components=[])
+
+    async def moderate(self, user_id: int, guild: hikari.Guild):
+        """DM, Kick, or Ban a user based on the determined restriction.
+
+        Args:
+            user_id (int): ID of the user to moderate.
+            guild (hikari.Guild): The guild that the user is verifying in.
+        """
+        if self.removed or self.action is None or self.restriction is None:
+            return
+
+        prompt = self.prompt(guild.name)
+        try:
+            # Only DM if the user is being kicked or banned.
+            if self.action != "dm":
+                channel = await bloxlink.rest.create_dm_channel(user_id)
+                await channel.send(embed=prompt)
+
+        except (hikari.BadRequestError, hikari.ForbiddenError, hikari.NotFoundError) as e:
+            logging.warning(e)
+
+        try:
+            log_reason = self._log_reason()
+            if self.action == "kick":
+                await bloxlink.rest.kick_user(guild.id, user_id, reason=log_reason)
+            elif self.action == "ban":
+                await bloxlink.rest.ban_user(guild.id, user_id, reason=log_reason)
+
+        except (hikari.ForbiddenError, hikari.NotFoundError):
+            pass
+        else:
+            if self.action != "dm":
+                self.removed = True
+
+    def _log_reason(self) -> str:
+        """Generate a string for the audit log entry when a user is kicked or banned.
+
+        Returns:
+            str: The resulting audit log string.
+        """
+        response: str = f"RESTRICTED: {self.restriction}, "
+
+        unverified: bool = self.metadata["unverified"]
+        description = "Not verified with Bloxlink."
+
+        try:
+            if unverified:
+                raise UserNotVerified()
+
+            match self.restriction:
+                case "ageLimit":
+                    age_limit_data = self.metadata["ageLimit"]
+                    description = (
+                        "User's Roblox account does not meet the agelimit. "
+                        f"{age_limit_data[1]} < {age_limit_data[0]} days."
+                    )
+
+                case "groupLock":
+                    group: RobloxGroup = self.metadata["group"]
+                    roleset_restriction = self.metadata["roleset"]
+
+                    if roleset_restriction:
+                        description = f"User is not the required rank in the group {str(group)}"
+                    else:
+                        description = f"User is not in the group {str(group)}"
+
+                case "banEvader":
+                    banned_id = self.metadata["banned_user"]
+                    description = f"User is an alt of the banned account {banned_id}"
+
+                case _:
+                    description = "User matched a restriction."
+        except UserNotVerified:
+            pass
+
+        return response + description
+
+
+async def check_guild_restrictions(guild_id: hikari.Snowflake, user_info: dict) -> Restriction | None:
+    """Check if a user should be kept from verifying in this guild_id.
+
+    Args:
+        guild_id (hikari.Snowflake): ID of the guild that the user is verifying in.
+        user_info (dict): Information of the user
+            Expected to have "id": the user id, and "account" which is a RobloxAccount.
+
+    Returns:
+        Restriction | None: Restriction info if the user should be restricted.
+    """
+    guild_data = await bloxlink.fetch_guild_data(
+        guild_id,
+        "ageLimit",
+        "disallowAlts",
+        "disallowBanEvaders",
+        "groupLock",
+    )
+
+    user_id = user_info["id"]
+    user_acc: users.RobloxAccount = user_info["account"]
+
+    # TODO: If server has premium and user_acc
+    if user_acc:
+        bloxlink_user: UserData = await bloxlink.fetch_user_data(user_id, "robloxID", "robloxAccounts")
+
+        accounts = bloxlink_user.robloxAccounts["accounts"]
+        accounts.append(bloxlink_user.robloxID)
+        accounts = list(set(accounts))
+
+        result = await check_premium_restrictions(
+            guild_data.disallowAlts,
+            guild_data.disallowBanEvaders,
+            user_id,
+            guild_id,
+            accounts,
+        )
+
+        if result:
+            return result
+
+    if guild_data.ageLimit:
+        if not user_acc:
+            return Restriction(action="kick", restriction="ageLimit", metadata={"unverified": True})
+
+        if user_acc.age_days < guild_data.ageLimit:
+            return Restriction(
+                action="kick",
+                restriction="ageLimit",
+                metadata={"unverified": False, "ageLimit": (guild_data.ageLimit, user_acc.age_days)},
+            )
+
+    if guild_data.groupLock:
+        if not user_acc:
+            kick_unverified = any(
+                g.get("unverifiedAction", "kick") == "kick" for g in guild_data.groupLock.values()
+            )
+
+            return Restriction(
+                action="kick" if kick_unverified else "dm",
+                restriction="groupLock",
+                metadata={"unverified": True},
+            )
+
+        if user_acc.groups is None:
+            await user_acc.sync(includes=["groups"])
+
+        for group_id, group_data in guild_data.groupLock.items():
+            action = group_data.get("verifiedAction", "dm")
+            required_rolesets = group_data.get("roleSets")
+
+            dm_message = group_data.get("dmMessage")
+
+            group_match: RobloxGroup = user_acc.groups.get(group_id)
+            group = group_match if group_match is not None else RobloxGroup(group_id)
+            await group.sync()
+
+            if group_match is None:
+                return Restriction(
+                    action=action,
+                    restriction="groupLock",
+                    metadata={"unverified": False, "group": group, "dmMessage": dm_message, "roleset": False},
+                )
+
+            user_roleset = group_match.user_roleset["rank"]
+            for roleset in required_rolesets:
+                if isinstance(roleset, list):
+                    # within range
+                    if roleset[0] <= user_roleset <= roleset[1]:
+                        break
+                else:
+                    # exact match (x) or inverse match (rolesets above x)
+                    if (user_roleset == roleset) or (roleset < 0 and abs(roleset) <= user_roleset):
+                        break
+            else:
+                # no match was found - restrict the user.
+                return Restriction(
+                    action=action,
+                    restriction="groupLock",
+                    metadata={"unverified": False, "group": group, "dmMessage": dm_message, "roleset": True},
+                )
+
+
+async def check_premium_restrictions(
+    check_alts: bool,
+    check_ban_evaders: str | None,
+    user_id: int,
+    guild_id: int,
+    user_accounts: list,
+) -> Restriction | None:
+    """Check for alts and ban evaders within a server for a user.
+
+    Args:
+        check_alts (bool): Should we check for alts
+        check_ban_evaders (str | None): Should we check for ban evaders
+        user_id (int): Discord ID of the user being updated
+        guild_id (int): Guild ID where the user is being updated
+        user_accounts (list): Roblox accounts linked to this user_id
+
+    Returns:
+        Restriction | None: Restriction info if the user is ban evading or an alt account
+            was found.
+    """
+    if not check_alts and (not check_ban_evaders or check_ban_evaders is None):
+        return
+
+    matches = []
+    for account in user_accounts:
+        matches.extend(await bloxlink.reverse_lookup(account, user_id))
+
+    alts_found: bool = False
+    for user in matches:
+        # sanity check, shouldn't be included but just in case.
+        if str(user_id) == user:
+            continue
+
+        if check_alts:
+            member = await bloxlink.fetch_discord_member(guild_id, user, "id")
+
+            if member is not None:
+                # We kick the old user here because otherwise the restriction will remove the original
+                # user based on the code setup.
+
+                try:
+                    await bloxlink.rest.kick_user(
+                        guild_id, user, reason=f"User is an alt of {user_id} and disallowAlts is enabled."
+                    )
+
+                    alts_found = True
+
+                except (hikari.NotFoundError, hikari.ForbiddenError):
+                    pass
+
+                # We don't return so we can continue checking for more alts if they exist & kick them too.
+                # Plus, returning will prevent ban evader checking.
+
+        if check_ban_evaders:
+            try:
+                await bloxlink.rest.fetch_ban(guild_id, user)
+            except hikari.NotFoundError:
+                continue
+            except hikari.ForbiddenError:
+                continue
+            else:
+                return Restriction(
+                    action="ban",
+                    restriction="banEvader",
+                    metadata={"unverified": False, "banned_user": user},
+                )
+
+        if alts_found:
+            return Restriction(
+                action="dm",
+                restriction="disallowAlts",
+                metadata={"unverified": False},
+            )

--- a/src/resources/roblox/groups.py
+++ b/src/resources/roblox/groups.py
@@ -15,6 +15,7 @@ ROBLOX_GROUP_REGEX = re.compile(r"roblox.com/groups/(\d+)/")
 class RobloxGroup(PartialMixin, RobloxEntity):
     member_count: int = None
     rolesets: dict[int, str] = None
+    user_roleset: dict = None
 
     async def sync(self):
         """Retrieve the roblox group information, consisting of rolesets, name, description, and member count."""

--- a/src/resources/roblox/users.py
+++ b/src/resources/roblox/users.py
@@ -162,7 +162,6 @@ class RobloxAccount(PartialMixin):
             group: groups.RobloxGroup = groups.RobloxGroup(
                 id=str(group_meta["id"]),
                 name=group_meta["name"],
-                my_role={"name": group_role["name"].strip(), "rank": group_role["rank"]},
             )  # seems redundant, but this is so we can switch the endpoint and retain consistency
             await group.sync()
             self.groups[group.id] = group

--- a/src/resources/roblox/users.py
+++ b/src/resources/roblox/users.py
@@ -162,6 +162,7 @@ class RobloxAccount(PartialMixin):
             group: groups.RobloxGroup = groups.RobloxGroup(
                 id=str(group_meta["id"]),
                 name=group_meta["name"],
+                user_roleset=group_role,
             )  # seems redundant, but this is so we can switch the endpoint and retain consistency
             await group.sync()
             self.groups[group.id] = group


### PR DESCRIPTION
This enables the code to check for and moderate users who apply to these restrictions:
- [X] Roblox age limit 
- [X] Group locks (users must be either in a group or a rank/rank range)
- [X] Ban evaders 
- [X] Alt accounts

This does not include logic to handle users who are restricted via `/restrict add` functionality.