### PR TITLE
Add endpoint for the member join event to use.

### DIFF
--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -811,9 +811,10 @@ async def apply_binds(
         embed = hikari.Embed(
             title="Member Updated",
         )
+
         embed.set_author(
             name=username,
-            icon=avatar_url,
+            icon=avatar_url or None,
             url=roblox_account.profile_link if roblox_account else None,
         )
 

--- a/src/resources/binds.py
+++ b/src/resources/binds.py
@@ -577,6 +577,7 @@ async def apply_binds(
     roblox_account: users.RobloxAccount = None,
     *,
     moderate_user=False,
+    mention_roles=True,
 ) -> EmbedPrompt:
     """Apply bindings to a user, (apply the Verified & Unverified roles, nickname template, and custom bindings).
 
@@ -589,6 +590,7 @@ async def apply_binds(
             or may not be their primary account, could be a guild-specific link. Defaults to None.
         moderate_user (bool, optional): Check if any restrictions (age limit, group lock,
             ban evasion, alt detection) apply to this user. Defaults to False.
+        mention_roles (bool, optional): Should roles be mentioned in the reply embed. Defaults to True.
 
     Raises:
         Message: Raised if there was an issue getting a server's bindings.
@@ -819,10 +821,16 @@ async def apply_binds(
         )
 
         if add_roles:
-            embed.add_field(name="Added Roles", value=",".join([r.mention for r in add_roles]))
+            embed.add_field(
+                name="Added Roles",
+                value=", ".join([r.mention if mention_roles else r.name for r in add_roles]),
+            )
 
         if remove_roles:
-            embed.add_field(name="Removed Roles", value=",".join([r.mention for r in remove_roles]))
+            embed.add_field(
+                name="Removed Roles",
+                value=",".join([r.mention if mention_roles else r.name for r in remove_roles]),
+            )
 
         if not add_roles and not remove_roles:
             embed.add_field(

--- a/src/resources/bloxlink.py
+++ b/src/resources/bloxlink.py
@@ -54,9 +54,12 @@ class GuildData:
     unverifiedRole: str = None
 
     ageLimit: int = None
+    autoRoles: bool = None
+    autoVerification: bool = None
     disallowAlts: bool = None
     disallowBanEvaders: str = None  # Site sets it to "ban" when enabled. Null when disabled.
     groupLock: dict = None
+    highTrafficServer: bool = None
 
     nicknameTemplate: str = "{smart-name}"
 

--- a/src/web/decorators.py
+++ b/src/web/decorators.py
@@ -1,8 +1,10 @@
-from functools import wraps
-from blacksheep import Request, unauthorized
-from resources.secrets import SERVER_AUTH  # pylint: disable=no-name-in-module
-from blacksheep.server.normalization import ensure_response
 import logging
+from functools import wraps
+
+from blacksheep import Request, unauthorized
+from blacksheep.server.normalization import ensure_response
+
+from resources.secrets import SERVER_AUTH  # pylint: disable=no-name-in-module
 
 logger = logging.getLogger()
 
@@ -12,20 +14,26 @@ UNAUTHORIZED_RESPONSE = unauthorized("You are not authorized to use this endpoin
 def authenticate():
     def decorator(handler):
         @wraps(handler)
-        async def wrapped(endpoint, request: Request):
-            auth_header = request.get_first_header(b"Authorization").decode() if request.has_header(b"Authorization") else None
-
+        async def wrapped(*args, **kwargs):
             # In case we ever omit the server auth config, we forbid all requests.
             if not SERVER_AUTH:
                 logger.error("No SERVER_AUTH was set! Blocking all requests.")
                 return UNAUTHORIZED_RESPONSE
 
+            # Find the Request typed argument. Will not work if the handler does not want the Request obj.
+            request = next((arg for arg in args if isinstance(arg, Request)), None)
+            if request is None:
+                return UNAUTHORIZED_RESPONSE
+
+            auth_header = (
+                request.get_first_header(b"Authorization").decode()
+                if request.has_header(b"Authorization")
+                else None
+            )
             if auth_header != SERVER_AUTH:
                 return UNAUTHORIZED_RESPONSE
 
-            response = ensure_response(await handler(endpoint, request))
-
-            return response
+            return ensure_response(await handler(*args, **kwargs))
 
         return wrapped
 

--- a/src/web/endpoints/update.py
+++ b/src/web/endpoints/update.py
@@ -1,13 +1,17 @@
 import logging
-from attrs import define
 
+from attrs import define
 from blacksheep import FromJSON, Request, ok
 from blacksheep.server.controllers import APIController, get, post
+from hikari import ForbiddenError
 
 import resources.binds as binds
 import resources.roblox.users as users
+from resources.bloxlink import GuildData
 from resources.bloxlink import instance as bloxlink
 from resources.exceptions import BloxlinkForbidden, Message
+from resources.utils import default_field
+
 from ..decorators import authenticate
 
 
@@ -31,24 +35,44 @@ class UpdateBody:
     is_done: bool = False
 
 
+@define
+class MinimalMember:
+    id: str
+    name: str
+    discriminator: int = None
+    avatar_url: str = None
+    is_bot: bool = None
+    created_at: str = None
+
+    activity: str = None
+    nickname: str = None
+    guild_id: str = None
+    guild_avatar: str = None
+    permissions: int = None
+    joined_at: str = None
+    roles: list = default_field([])
+    is_owner: bool = None
+
+
 class Update(APIController):
     """Results in a path of <URL>/api/update/..."""
 
     @get("/users")
     @authenticate()
-    async def get_user(self, request: Request):
+    async def get_users(self, _request: Request):
         """Endpoint to get a user, just for testing availability currently."""
         return ok("GET request to this route was valid.")
 
     @post("/users")
     @authenticate()
-    async def post_user(self, content: FromJSON[UpdateBody]):
+    async def post_users(self, content: FromJSON[UpdateBody], _request: Request):
         """Endpoint to receive /verifyall user chunks from the gateway.
 
         Args:
             content (FromJSON[UpdateBody]): Request data from the gateway.
                 See UpdateBody for expected JSON variables.
         """
+
         content: UpdateBody = content.value
 
         # Update users, send response only when this is done (or there is an issue?)
@@ -59,6 +83,50 @@ class Update(APIController):
         # Either the gateway should TTL after some time frame, or we should reply with a 202 (accepted) as soon
         # as the request is received, with a way to check the status (like nonces?)
         return ok(f"OK. Received {content}")
+
+    @post("/join/{guild_id}/{user_id}")
+    @authenticate()
+    async def update_on_join(
+        self,
+        guild_id: str,
+        user_id: str,
+        user_data: FromJSON[MinimalMember],
+        _request: Request,
+    ):
+        user_data: MinimalMember = user_data.value
+        guild_data: GuildData = await bloxlink.fetch_guild_data(
+            guild_id, "autoRoles", "autoVerification", "highTrafficServer"
+        )
+
+        if guild_data.highTrafficServer:
+            return ok("High traffic server is enabled, user was not updated.")
+
+        if guild_data.autoVerification or guild_data.autoRoles:
+            # print(user_data)
+            roblox_account = await users.get_user_account(user_id, guild_id=guild_id, raise_errors=False)
+            bot_response = await binds.apply_binds(
+                {
+                    "id": user_id,
+                    "role_ids": user_data.roles,
+                    "username": user_data.name,
+                    "nickname": user_data.nickname,
+                    "avatar_url": user_data.avatar_url,
+                },
+                guild_id,
+                roblox_account,
+                moderate_user=True,
+                mention_roles=False,
+            )
+
+            try:
+                dm_channel = await bloxlink.rest.create_dm_channel(user_id)
+                await dm_channel.send(embed=bot_response.embed, components=bot_response.action_rows)
+            except ForbiddenError:
+                pass
+
+            return ok("User was updated in the server.")
+
+        return ok("Server does not have auto-update features enabled.")
 
 
 async def _update_users(content: UpdateBody):

--- a/src/web/endpoints/update.py
+++ b/src/web/endpoints/update.py
@@ -93,6 +93,13 @@ class Update(APIController):
         user_data: FromJSON[MinimalMember],
         _request: Request,
     ):
+        """Endpoint to handle guild member join events from the gateway.
+
+        Args:
+            guild_id (str): The guild ID the user joined.
+            user_id (str): The ID of the user.
+            user_data (FromJSON[MinimalMember]): Additional user data from the gateway.
+        """
         user_data: MinimalMember = user_data.value
         guild_data: GuildData = await bloxlink.fetch_guild_data(
             guild_id, "autoRoles", "autoVerification", "highTrafficServer"


### PR DESCRIPTION
Fixes:
- Authentication wrapper not supporting all request types
  - Args and kwargs were consumed by the wrapper as well. 
- Role mentions in DMs would show as `@deleted-role` 
- apply_binds message would error if the avatar_url was not passed
- ~~"Roles up to date" message was showing when it was not supposed to~~
  - ~~*I could've sworn I fixed this before...?*~~ This was fixed on the bind_migration branch, but I did not realize that prior to fixing it again. 

Adds:
- /join/{guild_id}/{user_id} endpoint to the exposed endpoints

A new endpoint was chosen to be added over using the /update/users endpoint since the users endpoint is meant for updating multiple groups of users at a time, without allowing options such as DMing users. This endpoint solely focuses on handling the join event.